### PR TITLE
Add ability to color SegmentioCell objects based on position, not current state

### DIFF
--- a/Segmentio/Source/Cells/SegmentioCell.swift
+++ b/Segmentio/Source/Cells/SegmentioCell.swift
@@ -19,6 +19,8 @@ class SegmentioCell: UICollectionViewCell {
     var containerView: UIView?
     var imageContainerView: UIView?
     
+    var overrideTextColor: UIColor?
+    
     var topConstraint: NSLayoutConstraint?
     var bottomConstraint: NSLayoutConstraint?
     var cellSelected = false
@@ -42,11 +44,15 @@ class SegmentioCell: UICollectionViewCell {
                 
                 if style.isWithText() {
                     let highlightedTitleTextColor = cellSelected ? selectedState.titleTextColor
-                        : defaultState.titleTextColor
+                            : defaultState.titleTextColor
                     let highlightedTitleFont = cellSelected ? selectedState.titleFont : defaultState.titleFont
                     
+                    if let overrideTextColor = overrideTextColor {
+                        segmentTitleLabel?.textColor = overrideTextColor
+                    } else {
                     segmentTitleLabel?.textColor = isHighlighted ? highlightedState.titleTextColor
                         : highlightedTitleTextColor
+                    }
                     segmentTitleLabel?.font = isHighlighted ? highlightedState.titleFont : highlightedTitleFont
                 }
                 
@@ -139,7 +145,11 @@ class SegmentioCell: UICollectionViewCell {
         let defaultState = options.states.defaultState
         
         if style.isWithText() {
-            segmentTitleLabel?.textColor = selected ? selectedState.titleTextColor : defaultState.titleTextColor
+            if let overrideTextColor = overrideTextColor {
+                segmentTitleLabel?.textColor = overrideTextColor
+            } else {
+                segmentTitleLabel?.textColor = selected ? selectedState.titleTextColor : defaultState.titleTextColor
+            }
             segmentTitleLabel?.font = selected ? selectedState.titleFont : defaultState.titleFont
             segmentTitleLabel?.minimumScaleFactor = 0.5
             segmentTitleLabel?.adjustsFontSizeToFitWidth = true
@@ -290,11 +300,12 @@ class SegmentioCell: UICollectionViewCell {
             }
         }
         
+        overrideTextColor = content.overrideTextColor
         if style.isWithText() {
             segmentTitleLabel?.textAlignment = options.labelTextAlignment
             segmentTitleLabel?.numberOfLines = options.labelTextNumberOfLines
             let defaultState = options.states.defaultState
-            segmentTitleLabel?.textColor =  content.textColor ??  defaultState.titleTextColor
+            segmentTitleLabel?.textColor = overrideTextColor ?? defaultState.titleTextColor
             segmentTitleLabel?.font = defaultState.titleFont
             segmentTitleLabel?.text = content.title
             segmentTitleLabel?.minimumScaleFactor = 0.5

--- a/Segmentio/Source/Cells/SegmentioCell.swift
+++ b/Segmentio/Source/Cells/SegmentioCell.swift
@@ -285,13 +285,16 @@ class SegmentioCell: UICollectionViewCell {
         if style.isWithImage() {
             segmentImageView?.contentMode = options.imageContentMode
             segmentImageView?.image = content.image
+            if let imageTintColor = content.imageTintColor {
+                segmentImageView?.tintColor = imageTintColor
+            }
         }
         
         if style.isWithText() {
             segmentTitleLabel?.textAlignment = options.labelTextAlignment
             segmentTitleLabel?.numberOfLines = options.labelTextNumberOfLines
             let defaultState = options.states.defaultState
-            segmentTitleLabel?.textColor = defaultState.titleTextColor
+            segmentTitleLabel?.textColor =  content.textColor ??  defaultState.titleTextColor
             segmentTitleLabel?.font = defaultState.titleFont
             segmentTitleLabel?.text = content.title
             segmentTitleLabel?.minimumScaleFactor = 0.5

--- a/Segmentio/Source/SegmentioOptions.swift
+++ b/Segmentio/Source/SegmentioOptions.swift
@@ -13,7 +13,7 @@ import UIKit
 public struct SegmentioItem {
     
     public var title: String?
-    public var textColor: UIColor?
+    public var overrideTextColor: UIColor?
     public var image: UIImage?
     public var selectedImage: UIImage?
     public var imageTintColor: UIColor?
@@ -26,9 +26,9 @@ public struct SegmentioItem {
         return label.intrinsicContentSize.width
     }
 
-    public init(title: String?, image: UIImage?, selectedImage: UIImage? = nil, titleColor: UIColor? = nil, imageTintColor: UIColor? = nil) {
+    public init(title: String?, image: UIImage?, selectedImage: UIImage? = nil, imageTintColor: UIColor? = nil, overrideTextColor: UIColor? = nil) {
         self.title = title
-        self.textColor = titleColor
+        self.overrideTextColor = overrideTextColor
         self.image = image
         self.selectedImage = selectedImage ?? image
         self.imageTintColor = imageTintColor

--- a/Segmentio/Source/SegmentioOptions.swift
+++ b/Segmentio/Source/SegmentioOptions.swift
@@ -13,8 +13,10 @@ import UIKit
 public struct SegmentioItem {
     
     public var title: String?
+    public var textColor: UIColor?
     public var image: UIImage?
     public var selectedImage: UIImage?
+    public var imageTintColor: UIColor?
     public var badgeCount: Int?
     public var badgeColor: UIColor?
     public var intrinsicWidth: CGFloat {
@@ -24,10 +26,12 @@ public struct SegmentioItem {
         return label.intrinsicContentSize.width
     }
 
-    public init(title: String?, image: UIImage?, selectedImage: UIImage? = nil) {
+    public init(title: String?, image: UIImage?, selectedImage: UIImage? = nil, titleColor: UIColor? = nil, imageTintColor: UIColor? = nil) {
         self.title = title
+        self.textColor = titleColor
         self.image = image
         self.selectedImage = selectedImage ?? image
+        self.imageTintColor = imageTintColor
     }
     
     public mutating func addBadge(_ count: Int, color: UIColor) {


### PR DESCRIPTION
We need the ability to both tint images and color text that shows up in SegmentioCell objects based on their position.  This PR adds `overrideTextColor` and `imageTintColor` properties to SegmentioItem objects, and colors them appropriately in the SegmentioCell object.